### PR TITLE
Read PORT env variable

### DIFF
--- a/src/main/java/is/ru/hugb/calc/CalcWeb.java
+++ b/src/main/java/is/ru/hugb/calc/CalcWeb.java
@@ -4,6 +4,7 @@ import static spark.Spark.*;
 
 public class CalcWeb {
     public static void main(String[] args) {
+        port(getHerokuPort());
         get("/", (req, res) -> {
             return "No route specified. Try /add/1,2";
         });
@@ -11,6 +12,14 @@ public class CalcWeb {
             "/add/:input",
             (req, res) -> add(req.params(":input"))
         );
+    }
+
+    static int getHerokuPort() {
+        ProcessBuilder psb = new ProcessBuilder();
+	if (psb.environment().get("PORT") != null) {
+	    return Integer.parseInt(psb.environment().get("PORT"));
+	}
+	return 4567;
     }
 
     private static int add(String input) {


### PR DESCRIPTION
This makes Spark Heroku compliant. Will default to PORT 4567 if not
specified as an env variable.